### PR TITLE
Added try/except for LLDP

### DIFF
--- a/bin/ceos-topo
+++ b/bin/ceos-topo
@@ -45,8 +45,11 @@ def parse_args():
 def enable_lldp(networks):
     import subprocess
     for each in networks:
-        cmd = 'echo 16384 > /sys/class/net/br-{}/bridge/group_fwd_mask'.format(each.network.id[:12])
-        subprocess.call(cmd, shell=True)
+        try:
+            cmd = 'echo 16384 > /sys/class/net/br-{}/bridge/group_fwd_mask'.format(each.network.id[:12])
+            subprocess.call(cmd, shell=True)
+        except:
+            continue
     return
 
 


### PR DESCRIPTION
Added try/except logic for `enable_lldp(networks)` - on my Ubuntu docker host, not all networks succeed. While I still need to troubleshoot that issue, I don't think this should return an error.