### PR TITLE
add tty=True to fix proper container startup on mac os x devices

### DIFF
--- a/bin/docker-topo
+++ b/bin/docker-topo
@@ -248,7 +248,8 @@ class Device(object):
                 hostname=self.name,
                 ports=self.ports,
                 sysctls=self.sysctls,
-                labels={PREFIX: self.name}
+                labels={PREFIX: self.name},
+                tty=True
             )
 
     def get(self):


### PR DESCRIPTION
to make sure that we can also run cEOS topos on our working laptops :-)