### PR TITLE
PR to fix issue #17 - pyroute2: no IPRoute module for the platform on macOS Mojave 10.14.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     scripts=["bin/docker-topo"],
     data_files=collect_files(),
     python_requires=">=3.5",
-    install_requires=["pyyaml", "docker", "netaddr", "pyroute2==0.5.2"],
+    install_requires=["pyyaml", "docker", "netaddr", "pyroute2==0.5.3"],
     url="https://github.com/networkop/docker-topo",
     license="BSD3",
     author="Michael Kashin",


### PR DESCRIPTION
Change version of pyroute2 to allow execution on mac system as previous version claimed IPRoute did not have module for that platform
```
ImportError: no IPRoute module for the platform
```