### PR TITLE
Fix permissions to the kvm

### DIFF
--- a/topo-extra-files/cvp/build.sh
+++ b/topo-extra-files/cvp/build.sh
@@ -25,7 +25,7 @@ check_if_file_exists cvp.tgz
 check_if_file_exists cvp-tools.tgz
 check_if_file_exists answers.yaml
 
-chmod 660 /dev/kvm && chown root:qemu /dev/kvm
+
 
 CMD="docker build -t cvp ."
 echo $CMD

--- a/topo-extra-files/cvp/entrypoint.sh
+++ b/topo-extra-files/cvp/entrypoint.sh
@@ -41,6 +41,9 @@ ip link set dev virbr1 up
 # Generate ISO
 /tmp/geniso.py  -y /tmp/answers.yaml -p cvpadmin -o /tmp/
 
+echo 'Setting /dev/kvm permissions'
+chmod 660 /dev/kvm && chown root:qemu /dev/kvm
+
 # Generate libvirt XML
 /tmp/generateXmlForKvm.py -n cvp \
 --device-bridge virbr0 --cluster-bridge virbr1 -i /tmp/cvpTemplate.xml -o result.xml \


### PR DESCRIPTION
entrypoint permissions fix:
019-06-13 19:22:12.012+0000: 38: error : qemuProcessReportLogError:1922 : internal error: qemu unexpectedly closed the monitor: Could not access KVM kernel module: Permission denied
failed to initialize KVM: Permission denied
2019-06-13 19:22:12.012+0000: 41: error : qemuProcessReportLogError:1922 : internal error: process exited while connecting to monitor: Could not access KVM kernel module: Permission denied
failed to initialize KVM: Permission denied
error: Failed to start domain cvp
error: internal error: process exited while connecting to monitor: Could not access KVM kernel module: Permission denied
failed to initialize KVM: Permission denied

build.sh permissions fix:
chmod: changing permissions of '/dev/kvm': Operation not permitted