### PR TITLE
Support latest image tag for latest images

### DIFF
--- a/bin/docker-topo
+++ b/bin/docker-topo
@@ -413,7 +413,7 @@ class CEOS(Device):
                                "SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT": 1,
                                "INTFTYPE": "eth"
                            }
-        if version.parse(ceos_version) > version.parse("4.22.2F"):
+        if ceos_version == "latest" or version.parse(ceos_version) > version.parse("4.22.2F"):
             self.command += " systemd.setenv=INTFTYPE=eth"
             self.command += " systemd.setenv=ETBA=1"
             self.command += " systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1"


### PR DESCRIPTION
Code mentions
```
This assumes that docker image tag contains the correct EOS version, e.g. ceos:4.20.5
```

but in practice all the examples provided here contain "latest" as the EOS version. docker-topo will fail to start containers with recent images tagged as latest as the command line is incorrect, so we fix this specific case here.