### PR TITLE
statically defining centos:7

### DIFF
--- a/topo-extra-files/veos/Dockerfile
+++ b/topo-extra-files/veos/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 # Include epel for python-pip and update cache
 RUN yum -y install epel-release && \


### PR DESCRIPTION
Changes in CentOS 8 deprecate packages required for the script to work. I propose statically defining CentOS 7. 