### PR TITLE
close unused NetNS instances

### DIFF
--- a/bin/docker-topo
+++ b/bin/docker-topo
@@ -591,15 +591,16 @@ class Veth(object):
             # TODO Could add veth.add_ip('1.1.1.1/24') and get rid of set_ips.sh script
             LOG.debug("Create an interface for container {}: {}".format(device.name, i.review()))
         ns_name = device.sandbox.split('/')[-1]
-        with IPDB(nl=NetNS(ns_name)) as ns:
-            with ns.interfaces[interface] as i:
-                if int(i.address[1], 16) & 0x02 > 0:
-                    # MLAG mechanism uses the "locally administered bit" from the MAC address
-                    # and practically, the Mlag agent will core when set.
-                    LOG.debug(f"Changing interface mac from {i.address}")
-                    i.set_address(i.address[0] + "0" + i.address[2:]).commit()
-                    LOG.debug(f"to {i.address}")
-                i.up()
+        with NetNS(ns_name) as nl:
+            with IPDB(nl=nl) as ns:
+                with ns.interfaces[interface] as i:
+                    if int(i.address[1], 16) & 0x02 > 0:
+                        # MLAG mechanism uses the "locally administered bit" from the MAC address
+                        # and practically, the Mlag agent will core when set.
+                        LOG.debug(f"Changing interface mac from {i.address}")
+                        i.set_address(i.address[0] + "0" + i.address[2:]).commit()
+                        LOG.debug(f"to {i.address}")
+                    i.up()
  
 
 class Link(object):


### PR DESCRIPTION
IPDB() doesn't close `nl` on exit, if `nl` wasn't started
by IPDB(). It means that the code::

    with IPDB(nl=NetNS(ns_name)) as ipdb:
        ...

leaves NetNS() with open FDs on exit. It may lead to
resource limit issues.

Bug-Url: https://github.com/networkop/docker-topo/issues/39
Bug-Url: https://github.com/svinota/pyroute2/issues/698